### PR TITLE
Add toastr.clear() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ For other API calls, see the [demo](http://CodeSeven.github.com/toastr).
     // Display an error toast, with a title
     toastr.error('I do not think that word means what you tink it means.', 'Inconceivable!')
 
+    // Clears the current list of toasts
+    toastr.clear()
 
 ## Authors
 

--- a/index.html
+++ b/index.html
@@ -85,7 +85,8 @@
 				</div>
 
 				<div class="row span11">
-					<button type="button" class="btn btn-primary" id="showtoast">Show Toast</button>                
+					<button type="button" class="btn btn-primary" id="showtoast">Show Toast</button>    
+					<button type="button" class="btn btn-danger" id="cleartoasts">Clear Toasts</button>                
 				</div>
 			</div>
 		</section>
@@ -170,6 +171,10 @@
 					    })
 					}
 					
+				})
+
+				$('#cleartoasts').click(function() {
+					toastr.clear()
 				})
 			})
 		</script>

--- a/toastr.js
+++ b/toastr.js
@@ -160,6 +160,17 @@
                     message: message,
                     title: title
                 })
+            },
+
+            clear = function(){
+                var options = getOptions()
+                var $container = $('#' + options.containerId)
+                if ($container.length) {
+                    $container.fadeOut(options.fadeOut, function(){
+                        $container.remove()
+                    })
+                }
+
             }
 
         return {
@@ -167,7 +178,8 @@
             info: info,
             options: {},
             success: success,
-            warning: warning
+            warning: warning,
+            clear: clear
         }
     })()
 } (window, jQuery));


### PR DESCRIPTION
Not sure if this is worth pulling but it was useful to me!

This new method clears all currently displayed notifications. I needed that functionality to properly display errors during form validation because validation errors must not disappear by themselves (achieved with {timeOut: 0}), but must be cleared when they are not relevant anymore.

For example, if I toast an 'Email not valid' error, then the user fix the email and enters an invalid date, the previous email toast would still be there next to the new 'Invalid date'.

Now I just clear all toasts wherever the next toast is meant to be the only one (or the first one) displayed:

```
toastr.clear()
toastr.error('The battle of wits has begun.')
```

I also updated the demo and the readme file.
