### PR TITLE
Increased the z-index value of #toast-container 

### DIFF
--- a/toastr.css
+++ b/toastr.css
@@ -52,7 +52,7 @@
 
 #toast-container {
     position: fixed;
-    z-index: 9999;
+    z-index: 999999;
 }
 
     #toast-container > div {


### PR DESCRIPTION
Increased z-index in #toast-container. I was working with the asp.net toolkit and the ModalPopup control has a z-index of 100001. This caused the toaster to show below the ModalPopup window.
