### PR TITLE
Using options.containerId instead of getContainer()

### DIFF
--- a/toastr-1.1.5.js
+++ b/toastr-1.1.5.js
@@ -169,7 +169,7 @@
 
                 clear = function ($toastElement) {
                     var options = getOptions();
-                    var $container = $('#' + options.containerId);
+                    var $container = getContainer();
                     if ($toastElement && $(':focus', $toastElement).length === 0) {
                         var removeToast = function () {
                             if ($toastElement.is(':visible')) {


### PR DESCRIPTION
may leave some unintended errors with options.containerId
