### PR TITLE
Fixed error in 'clear' due to undefined options.

### DIFF
--- a/toastr-1.1.5.js
+++ b/toastr-1.1.5.js
@@ -170,7 +170,7 @@
 
                 clear = function ($toastElement) {
                     var options = getOptions();
-                    var $container = getContainer();
+                    var $container = getContainer(options);
                     if ($toastElement && $(':focus', $toastElement).length === 0) {
                         var removeToast = function () {
                             if ($toastElement.is(':visible')) {


### PR DESCRIPTION
The function call to `getContainer` in `clear` was missing the options argument which lead to a "TypeError: cannot read property 'containerId' of undefined" when calling `toastr.clear()`.
