### PR TITLE
Unwraps default 'target' attribute.

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -31,7 +31,7 @@
                     timeOut: 5000, // Set timeOut to 0 to make it sticky
                     titleClass: 'toast-title',
                     messageClass: 'toast-message',
-                    target: $('body')
+                    target: 'body'
                 },
 
                 error = function (message, title, optionsOverride) {
@@ -56,7 +56,7 @@
                     var
                         options = getOptions(),
                         iconClass = map.iconClass || options.iconClass;
-                    
+
                     if (typeof (map.optionsOverride) !== 'undefined') {
                         options = $.extend(options, map.optionsOverride);
                         iconClass = map.optionsOverride.iconClass || iconClass;


### PR DESCRIPTION
Fixes bug introduced by 95732a2df83a62da47e7dd9c8dfb2f8c906a7781, discussed in #64 - a `target` option was added as a jQuery-wrapped element selection, but the code tries to use `target` as a raw string. This breaks the code that appends the notification to the container, causing the notifications to not display at all.
