### PR TITLE
option to escape html in title and message

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -35,7 +35,8 @@
                     titleClass: 'toast-title',
                     messageClass: 'toast-message',
                     target: 'body',
-                    newestOnTop: true
+                    newestOnTop: true,
+                    escapeHtml: true
                 },
 
                 error = function (message, title, optionsOverride) {
@@ -79,12 +80,16 @@
                     }
 
                     if (map.title) {
-                        $titleElement.append(escapeHtml(map.title)).addClass(options.titleClass);
+                        $titleElement
+                            .append(options.escapeHtml ? escapeHtml(map.title) : map.title)
+                            .addClass(options.titleClass);
                         $toastElement.append($titleElement);
                     }
 
                     if (map.message) {
-                        $messageElement.append(escapeHtml(map.message)).addClass(options.messageClass);
+                        $messageElement
+                            .append(options.escapeHtml ? escapeHtml(map.message) : map.message)
+                            .addClass(options.messageClass);
                         $toastElement.append($messageElement);
                     }
 


### PR DESCRIPTION
add an option to escape html in title and message, to prevent message like `<script>alert('hey');</script>` get passed.
