### PR TITLE
Added bower info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Demo can be found at http://CodeSeven.github.com/toastr
 ## NuGet Gallery
 http://nuget.org/packages/toastr
 
+## [Bower](http://bower.io/)
+bower install toastr
+
 ## Quick start
 
 ###3 Easy Steps


### PR DESCRIPTION
I added a line to the readme with the [bower](http://bower.io/) install command for toastr
