### PR TITLE
Explicitly name jQuery in Node require() call for browserify support

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -261,7 +261,7 @@
 	});
 }(typeof define === 'function' && define.amd ? define : function (deps, factory) {
 	if (typeof module !== 'undefined' && module.exports) { //Node
-		module.exports = factory(require(deps[0]));
+		module.exports = factory(require('jquery'));
 	} else {
 		window['toastr'] = factory(window['jQuery']);
 	}


### PR DESCRIPTION
browserify can't properly handle require()s with expressions inside, and since `require(deps[0])` only ever comes out as `require('jquery')` in Toastr there's no particular reason not to put the jQuery identifier in the code directly. Having done this, browserify can detect the jQuery dependency and bundle jQuery with Toastr (as is required to have Toastr work).
