### PR TITLE
Close button stopPropagation spelling fix.

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -213,7 +213,7 @@
                 }
                 if (options.closeButton && $closeElement) {
                     $closeElement.click(function (event) {
-                        event.stopPropogation();
+                        event.stopPropagation();
                         hideToast(true);
                     });
                 }


### PR DESCRIPTION
Clicking close button currently causes error in console.
