### PR TITLE
Make it work with angular-mocks.js

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -298,7 +298,7 @@
 		})();
 	});
 }(typeof define === 'function' && define.amd ? define : function (deps, factory) {
-	if (typeof module !== 'undefined' && module.exports) { //Node
+	if (typeof define === "function" && typeof module !== 'undefined' && module.exports) { //Node
 		module.exports = factory(require(deps[0]));
 	} else {
 		window['toastr'] = factory(window['jQuery']);


### PR DESCRIPTION
Working with AngularJS and angular-mocks.js for test purposes, I got an error "Uncaught ReferenceError: require is not defined", because angular-mocks registers a module (I guess). By adding typeof define === "function" I was able to avoid this error.
