### PR TITLE
Persist options override

### DIFF
--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -73,6 +73,18 @@
             start();
         }, delay);
     });
+    asyncTest('clear - uses overridden options when clearing', 1, function () {
+        //Arrange
+        var $toast = toastr.info(sampleMsg, sampleTitle, { hideDuration: 200 });
+        toastr.clear($toast);
+        //Act
+        setTimeout(function () {
+            //Assert
+            equal($(selectors.container).children().length, 1);
+            resetContainer();
+            start();
+        }, 1);
+    });
     asyncTest('clear and show - show 2 toasts, clear both, then show 1 more', 2, function () {
         //Arrange
         var $toast = [];

--- a/toastr.js
+++ b/toastr.js
@@ -95,7 +95,7 @@
             }
 
             function clear($toastElement) {
-                var options = getOptions();
+                var options = getOptions($toastElement);
                 if (!$container) { getContainer(options); }
                 if (!clearToast($toastElement, options)) {
                     clearContainer(options);
@@ -211,6 +211,8 @@
                         map: map
                     };
 
+                $toastElement.data('toastr-options', options);
+
                 if (map.iconClass) {
                     $toastElement.addClass(options.toastClass).addClass(iconClass);
                 }
@@ -310,8 +312,13 @@
                 }
             }
 
-            function getOptions() {
-                return $.extend({}, getDefaults(), toastr.options);
+            function getOptions($toastElement) {
+                if($toastElement) {
+                    return $.extend({}, $toastElement.data('toastr-options'));
+                }
+                else {
+                    return $.extend({}, getDefaults(), toastr.options);
+                }
             }
 
             function removeToast($toastElement) {


### PR DESCRIPTION
Hi,

I use different configuration of toasts in my application, and some include changing how the toast is destroyed (ie: loading indicators gets destroyed without a fadeout and without delay).

The current version of Toastr does not allow this because the options are never saved. I suggest simply persisting them using jQuery's `data` mechanism.

I added both tests and code for this while following (or trying to) existing conventions and coding style, let me know if you see anything wrong.

Thanks,
Jimmy


