### PR TITLE
fix for options.target is ignored after first clear() or notify() issue

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -273,7 +273,7 @@
 				if (!options) { options = getOptions(); }
 				$container = $('#' + options.containerId);
 				if ($container.length) {
-					if (options.target && $container.parent() !== options.target) {
+					if (options.target && $container.parent()[0] !== $(options.target)[0]) {
 						$container.remove();
 					} else {
 						return $container;


### PR DESCRIPTION
Hi, 
There is a bug in that the options.target changes are ignored after $container was once created. I.e. it's impossible to move the toastr $container to other parent with a next notify() call. 
Same thing is when there was a call of toastr.clear() before toastr.notify(), it would be impossible to specify target with notify call options. 

A way to reproduce : 
1. http://jsfiddle.net/igoryan/zgs9F/2/
2. Click "Show on div2". Container stays the same, where it should have been moved to ".div2".

Please consider the proposed fix.
