### PR TITLE
Encode HTML by default

### DIFF
--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -379,6 +379,17 @@
         clearContainerChildren();
     });
 
+    module('html encoding');
+    test('encodes html by default', 1, function () {
+      var $toast = toastr.success('<b>hello</b>');
+      ok($toast.find('.toast-message').html() == '&lt;b&gt;hello&lt;/b&gt;', 'html is encoded');
+    });
+
+    test('allows to disable html encoding', 1, function () {
+      var $toast = toastr.success('<b>hello</b>', null, { html: true });
+      ok($toast.find('.toast-message').html() == '<b>hello</b>', 'html is not encoded');
+    });
+
     module('order of appearance');
     test('Newest toast on top', 1, function () {
         //Arrange

--- a/toastr.js
+++ b/toastr.js
@@ -221,7 +221,8 @@
                 }
 
                 if (map.message) {
-                    $messageElement.append(map.message).addClass(options.messageClass);
+                    var message_method = options.html ? 'html' : 'text';
+                    $messageElement[message_method](map.message).addClass(options.messageClass);
                     $toastElement.append($messageElement);
                 }
 


### PR DESCRIPTION
Encode HTML entities in the the message body, so that it'll display messages with special characters (`<`, `>`, `&`) correctly and avoid potential XSS vulnerabilities. This can be overridden by specifying an `html: true` option.

Also added two new tests for the new behavior.

I wasn't sure whether I should commit the new generated `toastr.min.js` file or not... I did not include it - let me know if I should.
