### PR TITLE
Added support for escaping message and title. 

### DIFF
--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -472,6 +472,74 @@
         resetContainer();
     });
 
+    module('Html escaping');
+    test('Message and title escaping disabled by default', 4, function () {
+        //Arrange
+        resetContainer();
+        //Act
+        var htmlTitle = '<div class="im-html-title">Can has html!</div>';
+        var htmlMessage = '<div class="im-html-msg">Can has html!</div>';
+        var $toast = toastr.success(htmlMessage, htmlTitle);
+        //Assert
+        var container = toastr.getContainer();
+        ok($(container).find('.im-html-title').length == 1, 'Element created inside toaster title');
+        ok($(container).find('.im-html-title').text() == 'Can has html!', 'Element has correct content');
+        ok($(container).find('.im-html-msg').length == 1, 'Element created inside toaster message');
+        ok($(container).find('.im-html-msg').text() == 'Can has html!', 'Element has correct content');
+        //Teardown
+        $toast.remove();
+        resetContainer();
+    });
+
+    test('Message escaped if escapeHtml enabled', 2, function () {
+        //Arrange
+        resetContainer();
+        toastr.options.escapeHtml = true;
+        //Act
+        var htmlMessage = '<div class="im-html-element">I\'m escaped</div>';
+        var $toast = toastr.success(htmlMessage);
+        //Assert
+        var escaped = '&lt;div class="im-html-element"&gt;I\'m escaped&lt;/div&gt;';
+        ok($toast.find('.im-html-element').length == 0, "Element wasnt't created inside toaster");
+        ok($toast.find('.toast-message')[0].innerHTML == escaped, 'Element content escaped correctly');
+        //Teardown
+        $toast.remove();
+        resetContainer();
+    });
+
+    test('Title escaped if escapeHtml enabled', 1, function () {
+        //Arrange
+        resetContainer();
+        toastr.options.escapeHtml = true;
+        //Act
+        var htmlTitle = '<b>Hello,</b>';
+        var $toast = toastr.success('world!', htmlTitle);
+        //Assert
+        var escaped = '&lt;b&gt;Hello,&lt;/b&gt;';
+        ok($toast.find('.toast-title')[0].innerHTML == escaped, 'Element content escaped correctly');
+        //Teardown
+        $toast.remove();
+        resetContainer();
+    });
+
+    test('Can set escapeHtml per toast', 2, function () {
+        //Arrange
+        resetContainer();
+        toastr.options = {};
+        //Act
+        var originalMsg = '<b>Hello!</b>';
+        var escapedMsg = '&lt;b&gt;Hello!&lt;/b&gt;';
+        var $frist = toastr.success(originalMsg, null, { escapeHtml: true });
+        var $second = toastr.success(originalMsg);
+        //Assert
+        ok($frist.find('.toast-message')[0].innerHTML == escapedMsg, 'Element content should be escaped');
+        ok($second.find('.toast-message')[0].innerHTML == originalMsg, 'Element content should not be escaped');
+        //Teardown
+        $frist.remove();
+        $second.remove();
+        resetContainer();
+    });
+
     // These must go last
     module('positioning');
     test('Container - position top-right', 1, function () {

--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -529,13 +529,13 @@
         //Act
         var originalMsg = '<b>Hello!</b>';
         var escapedMsg = '&lt;b&gt;Hello!&lt;/b&gt;';
-        var $frist = toastr.success(originalMsg, null, { escapeHtml: true });
+        var $first = toastr.success(originalMsg, null, { escapeHtml: true });
         var $second = toastr.success(originalMsg);
         //Assert
-        ok($frist.find('.toast-message')[0].innerHTML == escapedMsg, 'Element content should be escaped');
+        ok($first.find('.toast-message')[0].innerHTML == escapedMsg, 'Element content should be escaped');
         ok($second.find('.toast-message')[0].innerHTML == originalMsg, 'Element content should not be escaped');
         //Teardown
-        $frist.remove();
+        $first.remove();
         $second.remove();
         resetContainer();
     });

--- a/toastr.js
+++ b/toastr.js
@@ -1,6 +1,6 @@
 /*
  * Toastr
- * Copyright 2012-2014 
+ * Copyright 2012-2014
  * Authors: John Papa, Hans Fjällemark, and Tim Ferrell.
  * All Rights Reserved.
  * Use, reproduction, distribution, and modification of this code is subject to the terms and
@@ -182,7 +182,8 @@
                     closeHtml: '<button>&times;</button>',
                     newestOnTop: true,
                     preventDuplicates: false,
-                    progressBar: false
+                    progressBar: false,
+                    escapeHtml: false
                 };
             }
 
@@ -217,6 +218,7 @@
                     $messageElement = $('<div/>'),
                     $progressElement = $('<div/>'),
                     $closeElement = $(options.closeHtml),
+                    insertMethod = 'append',
                     progressBar = {
                         intervalId: null,
                         hideEta: null,
@@ -230,17 +232,21 @@
                         map: map
                     };
 
+                if (options.escapeHtml === true) {
+                    insertMethod = 'text';
+                }
+
                 if (map.iconClass) {
                     $toastElement.addClass(options.toastClass).addClass(iconClass);
                 }
 
                 if (map.title) {
-                    $titleElement.append(map.title).addClass(options.titleClass);
+                    $titleElement[insertMethod](map.title).addClass(options.titleClass);
                     $toastElement.append($titleElement);
                 }
 
                 if (map.message) {
-                    $messageElement.append(map.message).addClass(options.messageClass);
+                    $messageElement[insertMethod](map.message).addClass(options.messageClass);
                     $toastElement.append($messageElement);
                 }
 


### PR DESCRIPTION
Added support for automatically escaping toastr title and message to prevent XSS vulnerabilities when showing toast's. To not break backwards compatibility escaping is optional and disabled by default.

To enable escaping you can either set global option or toggle escaping on or off when showing toastr.

Set escaping on by default:
```javascript
toastr.options.escapeHtml = true;
toastr.success('<b>Hello!</b>');
```

Enable escaping for single toast: 
```javascript
toastr.success('<b>Hello!</b>', null, { escapeHtml: true });
```

This issue is has been raised before but was marked as wontfix because it would be breaking change. In this pull https://github.com/CodeSeven/toastr/pull/164 it was suggested that this is optional. 

Related issues/pull requests:
https://github.com/CodeSeven/toastr/pull/83
https://github.com/CodeSeven/toastr/pull/164
https://github.com/CodeSeven/toastr/issues/152