### PR TITLE
Added support for explicitly clearing a toast, which ignores the focus c...

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -293,7 +293,7 @@
             }
             if ($toast.find('.clear').length) {
                 $toast.delegate('.clear', 'click', function () {
-                    toastr.clear($toast, { ignoreFocus: true });
+                    toastr.clear($toast, { force: true });
                 });
             }
         });

--- a/demo.html
+++ b/demo.html
@@ -54,6 +54,11 @@
                             <input id="preventDuplicates" type="checkbox" value="checked" class="input-mini" />Prevent Duplicates
                         </label>
                     </div>
+                    <div class="controls">
+                        <label class="checkbox" for="addClear">
+                            <input id="addClear" type="checkbox" value="checked" class="input-mini" />Add Clear Button
+                        </label>
+                    </div>
                 </div>
             </div>
 
@@ -188,6 +193,12 @@
 
             return msgs[i];
         };
+        var getMessageWithClearButton = function (msg) {
+            msg = msg ? msg : 'Clear itself?';
+            msg += '<br /><br /><button type="button" class="clear">Yes</button>';
+            return msg;
+        };
+
         $('#showtoast').click(function () {
             var shortCutFunction = $("#toastTypeGroup input:radio:checked").val();
             var msg = $('#message').val();
@@ -201,6 +212,7 @@
             var $showMethod = $('#showMethod');
             var $hideMethod = $('#hideMethod');
             var toastIndex = toastCount++;
+            var addClear = $('#addClear').prop('checked');
 
             toastr.options = {
                 closeButton: $('#closeButton').prop('checked'),
@@ -226,11 +238,11 @@
             }
 
             if ($timeOut.val().length) {
-                toastr.options.timeOut = $timeOut.val();
+                toastr.options.timeOut = addClear ? 0 : $timeOut.val();
             }
 
             if ($extendedTimeOut.val().length) {
-                toastr.options.extendedTimeOut = $extendedTimeOut.val();
+                toastr.options.extendedTimeOut = addClear ? 0 : $extendedTimeOut.val();
             }
 
             if ($showEasing.val().length) {
@@ -249,8 +261,10 @@
                 toastr.options.hideMethod = $hideMethod.val();
             }
 
-
-
+            if (addClear) {
+                msg = getMessageWithClearButton(msg);
+                toastr.options.tapToDismiss = false;
+            }
             if (!msg) {
                 msg = getMessage();
             }
@@ -277,7 +291,13 @@
                     alert('Surprise! you clicked me. i was toast #' + toastIndex + '. You could perform an action here.');
                 });
             }
+            if ($toast.find('.clear').length) {
+                $toast.delegate('.clear', 'click', function () {
+                    toastr.clearExplicitly($toast);
+                });
+            }
         });
+
         function getLastToast(){
             return $toastlast;
         }

--- a/demo.html
+++ b/demo.html
@@ -293,7 +293,7 @@
             }
             if ($toast.find('.clear').length) {
                 $toast.delegate('.clear', 'click', function () {
-                    toastr.clearExplicitly($toast);
+                    toastr.clear($toast, { ignoreFocus: true });
                 });
             }
         });

--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -88,6 +88,20 @@
         //Teardown
         resetContainer();
     });
+    test('clear - after clear with ignoreFocus option toast with focus disappears', 1, function () {
+        //Arrange
+        var $toast;
+        var msg = sampleMsg + '<br/><br/><button type="button">Clear</button>';
+        //Act
+        $toast = toastr.info(msg, sampleTitle + '-1');
+        $toast.find('button').focus();
+        toastr.clear($toast, { ignoreFocus: true });
+        var $container = toastr.getContainer();
+        //Assert
+        ok($container && $container.children().length === 0, 'Focused toast after a clear with ignoreFocus is not visible');
+        //Teardown
+        resetContainer();
+    });
     asyncTest('clear and show - show 2 toasts, clear both, then show 1 more', 2, function () {
         //Arrange
         var $toast = [];
@@ -149,22 +163,6 @@
         $toast[2] = toastr.info(sampleMsg, sampleTitle + '-3-Visible');
         //Assert
         ok($toast[2].is(':visible'), 'Toast after a clear is visible');
-        //Teardown
-        resetContainer();
-    });
-    module('clearExplicitly');
-    test('clearExplicitly - after clearExplicitly toast with focus disappears', 1, function () {
-        //Arrange
-        var $toast;
-        var msg = sampleMsg + '<br/><br/><button type="button">Clear</button>';
-        //Act
-        $toast = toastr.info(msg, sampleTitle + '-1');
-        $toast.find('button').focus();
-        toastr.clearExplicitly($toast);
-        var $container = toastr.getContainer();
-        //Assert
-        ok($container && $container.children().length === 0, 'Focused toast after a clearExplicitly is not visible');
-        //ok($toast.is(':hidden'), 'Focused toast after a clearExplicitly is not visible');
         //Teardown
         resetContainer();
     });

--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -88,17 +88,17 @@
         //Teardown
         resetContainer();
     });
-    test('clear - after clear with ignoreFocus option toast with focus disappears', 1, function () {
+    test('clear - after clear with force option toast with focus disappears', 1, function () {
         //Arrange
         var $toast;
         var msg = sampleMsg + '<br/><br/><button type="button">Clear</button>';
         //Act
         $toast = toastr.info(msg, sampleTitle + '-1');
         $toast.find('button').focus();
-        toastr.clear($toast, { ignoreFocus: true });
+        toastr.clear($toast, { force: true });
         var $container = toastr.getContainer();
         //Assert
-        ok($container && $container.children().length === 0, 'Focused toast after a clear with ignoreFocus is not visible');
+        ok($container && $container.children().length === 0, 'Focused toast after a clear with force is not visible');
         //Teardown
         resetContainer();
     });

--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -75,6 +75,19 @@
             start();
         }, delay);
     });
+    test('clear - after clear toast with focus still appears', 1, function () {
+        //Arrange
+        var $toast;
+        var msg = sampleMsg + '<br/><br/><button type="button">Clear</button>';
+        //Act
+        $toast = toastr.info(msg, sampleTitle + '-1');
+        $toast.find('button').focus();
+        toastr.clear($toast);
+        //Assert
+        ok($toast.is(':visible'), 'Focused toast after a clear is visible');
+        //Teardown
+        resetContainer();
+    });
     asyncTest('clear and show - show 2 toasts, clear both, then show 1 more', 2, function () {
         //Arrange
         var $toast = [];
@@ -136,6 +149,22 @@
         $toast[2] = toastr.info(sampleMsg, sampleTitle + '-3-Visible');
         //Assert
         ok($toast[2].is(':visible'), 'Toast after a clear is visible');
+        //Teardown
+        resetContainer();
+    });
+    module('clearExplicitly');
+    test('clearExplicitly - after clearExplicitly toast with focus disappears', 1, function () {
+        //Arrange
+        var $toast;
+        var msg = sampleMsg + '<br/><br/><button type="button">Clear</button>';
+        //Act
+        $toast = toastr.info(msg, sampleTitle + '-1');
+        $toast.find('button').focus();
+        toastr.clearExplicitly($toast);
+        var $container = toastr.getContainer();
+        //Assert
+        ok($container && $container.children().length === 0, 'Focused toast after a clearExplicitly is not visible');
+        //ok($toast.is(':hidden'), 'Focused toast after a clearExplicitly is not visible');
         //Teardown
         resetContainer();
     });
@@ -312,7 +341,7 @@
         $toast.remove();
         clearContainerChildren();
     });
-	test('close button has type=button', 1, function () {
+    test('close button has type=button', 1, function () {
         //Arrange
         toastr.options.closeButton = true;
         //Act

--- a/toastr.js
+++ b/toastr.js
@@ -128,8 +128,8 @@
             }
 
             function clearToast ($toastElement, options, clearOptions) {
-                var ignoreFocus = clearOptions && clearOptions.ignoreFocus ? clearOptions.ignoreFocus : false;
-                if ($toastElement && (ignoreFocus || $(':focus', $toastElement).length === 0)) {
+                var force = clearOptions && clearOptions.force ? clearOptions.force : false;
+                if ($toastElement && (force || $(':focus', $toastElement).length === 0)) {
                     $toastElement[options.hideMethod]({
                         duration: options.hideDuration,
                         easing: options.hideEasing,

--- a/toastr.js
+++ b/toastr.js
@@ -25,7 +25,6 @@
 
             var toastr = {
                 clear: clear,
-                clearExplicitly: clearExplicitly,
                 remove: remove,
                 error: error,
                 getContainer: getContainer,
@@ -98,17 +97,12 @@
                 });
             }
 
-            function clear($toastElement) {
+            function clear($toastElement, clearOptions) {
                 var options = getOptions();
                 if (!$container) { getContainer(options); }
-                if (!clearToast($toastElement, options)) {
+                if (!clearToast($toastElement, options, clearOptions)) {
                     clearContainer(options);
                 }
-            }
-
-            function clearExplicitly($toastElement) {
-                var options = getOptions();
-                clearToastBase($toastElement, options);
             }
 
             function remove($toastElement) {
@@ -133,15 +127,9 @@
                 }
             }
 
-            function clearToast ($toastElement, options) {
-                if ($toastElement && $(':focus', $toastElement).length === 0) {
-                    return clearToastBase($toastElement, options);
-                }
-                return false;
-            }
-
-            function clearToastBase($toastElement, options) {
-                if ($toastElement) {
+            function clearToast ($toastElement, options, clearOptions) {
+                var ignoreFocus = clearOptions && clearOptions.ignoreFocus ? clearOptions.ignoreFocus : false;
+                if ($toastElement && (ignoreFocus || $(':focus', $toastElement).length === 0)) {
                     $toastElement[options.hideMethod]({
                         duration: options.hideDuration,
                         easing: options.hideEasing,

--- a/toastr.js
+++ b/toastr.js
@@ -25,6 +25,7 @@
 
             var toastr = {
                 clear: clear,
+                clearExplicitly: clearExplicitly,
                 remove: remove,
                 error: error,
                 getContainer: getContainer,
@@ -105,6 +106,11 @@
                 }
             }
 
+            function clearExplicitly($toastElement) {
+                var options = getOptions();
+                clearToastBase($toastElement, options);
+            }
+
             function remove($toastElement) {
                 var options = getOptions();
                 if (!$container) { getContainer(options); }
@@ -129,6 +135,13 @@
 
             function clearToast ($toastElement, options) {
                 if ($toastElement && $(':focus', $toastElement).length === 0) {
+                    return clearToastBase($toastElement, options);
+                }
+                return false;
+            }
+
+            function clearToastBase($toastElement, options) {
+                if ($toastElement) {
                     $toastElement[options.hideMethod]({
                         duration: options.hideDuration,
                         easing: options.hideEasing,
@@ -199,7 +212,7 @@
                     options = $.extend(options, map.optionsOverride);
                     iconClass = map.optionsOverride.iconClass || iconClass;
                 }
-                
+
                 if (options.preventDuplicates) {
                     if (map.message === previousToast) {
                         return;


### PR DESCRIPTION
I added a new clearExplicitly function that clears the toast without checking for focused elements. The idea is to give full control to the developer if they want to clear the toast regardless of focus! More info on issue #220 .