### PR TITLE
Bottom margin is overridden when position is top-center or bottom-center

### DIFF
--- a/toastr.less
+++ b/toastr.less
@@ -181,13 +181,15 @@ button.toast-close-button {
 	&.toast-top-center > div,
 	&.toast-bottom-center > div {
 		width: 300px;
-		margin: auto;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	&.toast-top-full-width > div,
 	&.toast-bottom-full-width > div {
 		width: 96%;
-		margin: auto;
+		margin-left: auto;
+		margin-right: auto;
 	}
 }
 


### PR DESCRIPTION
`margin: 0 0 6px` is overridden by `margin: auto`. `6px` is lost.