### PR TITLE
Remove unused dependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
   "devDependencies": {
     "del": "^0.1.3",
     "glob": "^4.0.6",
-    "grunt-contrib-less": "~0.6.4",
-    "grunt-contrib-uglify": "~0.2.2",
     "gulp": "^3.8.10",
     "gulp-bytediff": "^0.2.0",
     "gulp-jscs": "^1.3.0",


### PR DESCRIPTION
Avoids a confusing deprecation message related to grunt when running `npm install`.