### PR TITLE
Close animation overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ toastr.options.closeHtml = '<button><i class="icon-off"></i></button>';
 
 You can also override the CSS/LESS for `#toast-container .toast-close-button`
 
+Optionally override the hide animation when the close button is clicked (falls back to hide configuration).
+```js
+toastr.options.closeMethod = 'fadeOut';
+toastr.options.closeDuration = 300;
+toastr.options.closeEasing = 'swing';
+```
+
 ### Display Sequence
 Show newest toast at bottom (top is default)
 ```js
@@ -121,12 +128,14 @@ Optionally override the animation easing to show or hide the toasts. Default is 
 ```js
 toastr.options.showEasing = 'swing';
 toastr.options.hideEasing = 'linear';
+toastr.options.closeEasing = 'linear';
 ```
 
 Using the jQuery Easing plugin (http://www.gsgd.co.uk/sandbox/jquery/easing/)
 ```js
 toastr.options.showEasing = 'easeOutBounce';
 toastr.options.hideEasing = 'easeInBack';
+toastr.options.closeEasing = 'easeInBack';
 ```
 
 ####Animation Method
@@ -134,6 +143,7 @@ Use the jQuery show/hide method of your choice. These default to fadeIn/fadeOut.
 ```js
 toastr.options.showMethod = 'slideDown';
 toastr.options.hideMethod = 'slideUp';
+toastr.options.closeMethod = 'slideUp';
 ```
 	
 ###Prevent Duplicates

--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -337,6 +337,24 @@
         $toast.remove();
         clearContainerChildren();
     });
+    asyncTest('close button duration', 1, function () {
+        //Arrange
+        toastr.options.closeButton = true;
+        toastr.options.closeDuration = 0;
+        toastr.options.hideDuration = 2000;
+        var $container = toastr.getContainer();
+        //Act
+        var $toast = toastr.success('');
+        $toast.find('button.toast-close-button').click();
+        setTimeout(function () {
+            //Assert
+            ok($container && $container.children().length === 0, 'close button should support own hide animation');
+            //Teardown
+            toastr.options.hideDuration = 0;
+            resetContainer();
+            start();
+        }, 500);
+    });
 
     module('progressBar', {
         teardown: function () {

--- a/toastr.js
+++ b/toastr.js
@@ -349,18 +349,17 @@
                 }
 
                 function hideToast(override) {
-                    var opts = {};
-                    ['Method', 'Duration', 'Easing'].forEach(function(opt) {
-                        opts[opt.toLowerCase()] = override && options['close' + opt] !== false ?
-                            options['close' + opt] : options['hide' + opt];
-                    });
+                    var method = override && options.closeMethod !== false ? options.closeMethod : options.hideMethod;
+                    var duration = override && options.closeDuration !== false ?
+                        options.closeDuration : options.hideDuration;
+                    var easing = override && options.closeEasing !== false ? options.closeEasing : options.hideEasing;
                     if ($(':focus', $toastElement).length && !override) {
                         return;
                     }
                     clearTimeout(progressBar.intervalId);
-                    return $toastElement[opts.method]({
-                        duration: opts.duration,
-                        easing: opts.easing,
+                    return $toastElement[method]({
+                        duration: duration,
+                        easing: easing,
                         complete: function () {
                             removeToast($toastElement);
                             if (options.onHidden && response.state !== 'hidden') {

--- a/toastr.js
+++ b/toastr.js
@@ -167,6 +167,9 @@
                     hideDuration: 1000,
                     hideEasing: 'swing',
                     onHidden: undefined,
+                    closeMethod: false,
+                    closeDuration: false,
+                    closeEasing: false,
 
                     extendedTimeOut: 1000,
                     iconClasses: {
@@ -346,13 +349,18 @@
                 }
 
                 function hideToast(override) {
+                    var opts = {};
+                    ['Method', 'Duration', 'Easing'].forEach(function(opt) {
+                        opts[opt.toLowerCase()] = override && options['close' + opt] !== false ?
+                            options['close' + opt] : options['hide' + opt];
+                    });
                     if ($(':focus', $toastElement).length && !override) {
                         return;
                     }
                     clearTimeout(progressBar.intervalId);
-                    return $toastElement[options.hideMethod]({
-                        duration: options.hideDuration,
-                        easing: options.hideEasing,
+                    return $toastElement[opts.method]({
+                        duration: opts.duration,
+                        easing: opts.easing,
                         complete: function () {
                             removeToast($toastElement);
                             if (options.onHidden && response.state !== 'hidden') {


### PR DESCRIPTION
Add options `closeMethod`, `closeDuration`, and `closeEasing` for manually overriding the hide animation specifically when the close button is clicked.

Use case: I'd like to be able to set a high `hideDuration` (e.g., 5000), but if/when the close button is clicked, close nearly immediately (e.g., 0 - 300).