### PR TITLE
Removed the scheme from asset URLs in the demo.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>toastr examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <link href="toastr.css" rel="stylesheet" type="text/css" />
     <style>
         .row {
@@ -174,7 +174,7 @@
     </ul>
 </footer>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script src="toastr.js"></script>
 
 <script type="text/javascript">


### PR DESCRIPTION
The scheme (http/https) has been removed from URLs of assets (jQuery/bootstrap) so that the demo works correctly over TLS. Currently, bootstrap fails to load when viewing the demos over TLS, which means the page is devoid of all bootstrap styling.

This obviously isn't a huge issue as all inbound links are probably to the insecure. I use the [HTTPS Everywhere](https://www.eff.org/HTTPS-everywhere) browser extension, which checks if a page is being served over HTTPS and redirects you there if it is. The only way to view the demo in all it's glory is to completely disable the extension. As I already said, this is pretty much the smallest issue anyone could imagine, but it's also very easy to fix.