### PR TITLE
HTML escaping added

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ toastr.clear()
 toastr.success('We do have the Kapua suite available.', 'Turtle Bay Resort', {timeOut: 5000})
 ```
 
+### Escape HTML characters
+In case you want to escape HTML charaters in title and message
+
+	toastr.options.escapeHtml = true;
+
 ### Close Button
 Optionally enable a close button
 ```js

--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -299,6 +299,61 @@
         clearContainerChildren();
     });
 
+
+    module('escape html', {
+        teardown: function () {
+            toastr.options.escapeHtml = false;
+        }
+    });
+    test('info - escape html', 2, function () {
+        //Arrange
+        toastr.options.escapeHtml = true;
+        //Act
+        var $toast = toastr.info('html <strong>message</strong>', 'html <u>title</u>');
+        //Assert
+        equal($toast.find('div.toast-title').html(), 'html &lt;u&gt;title&lt;/u&gt;', 'Title is escaped');
+        equal($toast.find('div.toast-message').html(), 'html &lt;strong&gt;message&lt;/strong&gt;', 'Message is escaped');
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('warning - escape html', 2, function () {
+        //Arrange
+        toastr.options.escapeHtml = true;
+        //Act
+        var $toast = toastr.warning('html <strong>message</strong>', 'html <u>title</u>');
+        //Assert
+        equal($toast.find('div.toast-title').html(), 'html &lt;u&gt;title&lt;/u&gt;', 'Title is escaped');
+        equal($toast.find('div.toast-message').html(), 'html &lt;strong&gt;message&lt;/strong&gt;', 'Message is escaped');
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('error - escape html', 2, function () {
+        //Arrange
+        toastr.options.escapeHtml = true;
+        //Act
+        var $toast = toastr.error('html <strong>message</strong>', 'html <u>title</u>');
+        //Assert
+        equal($toast.find('div.toast-title').html(), 'html &lt;u&gt;title&lt;/u&gt;', 'Title is escaped');
+        equal($toast.find('div.toast-message').html(), 'html &lt;strong&gt;message&lt;/strong&gt;', 'Message is escaped');
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('success - escape html', 2, function () {
+        //Arrange
+        toastr.options.escapeHtml = true;
+        //Act
+        var $toast = toastr.success('html <strong>message</strong>', 'html <u>title</u>');
+        //Assert
+        equal($toast.find('div.toast-title').html(), 'html &lt;u&gt;title&lt;/u&gt;', 'Title is escaped');
+        equal($toast.find('div.toast-message').html(), 'html &lt;strong&gt;message&lt;/strong&gt;', 'Message is escaped');
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+
     module('closeButton', {
         teardown: function () {
             toastr.options.closeButton = false;

--- a/toastr.js
+++ b/toastr.js
@@ -183,6 +183,7 @@
                     timeOut: 5000, // Set timeOut and extendedTimeOut to 0 to make it sticky
                     titleClass: 'toast-title',
                     messageClass: 'toast-message',
+                    escapeHtml: false,
                     target: 'body',
                     closeHtml: '<button type="button">&times;</button>',
                     newestOnTop: true,
@@ -243,6 +244,18 @@
                 }
 
                 return $toastElement;
+
+                function escapeHtml(source) {
+                    if (source == null)
+                        source = "";
+
+                    return new String(source)
+                        .replace(/&/g, '&amp;')
+                        .replace(/"/g, '&quot;')
+                        .replace(/'/g, '&#39;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;');
+                }
 
                 function personalizeToast() {
                     setIcon();
@@ -311,14 +324,14 @@
 
                 function setTitle() {
                     if (map.title) {
-                        $titleElement.append(map.title).addClass(options.titleClass);
+                        $titleElement.append(!options.escapeHtml ? map.title : escapeHtml(map.title)).addClass(options.titleClass);
                         $toastElement.append($titleElement);
                     }
                 }
 
                 function setMessage() {
                     if (map.message) {
-                        $messageElement.append(map.message).addClass(options.messageClass);
+                        $messageElement.append(!options.escapeHtml ? map.message : escapeHtml(map.message)).addClass(options.messageClass);
                         $toastElement.append($messageElement);
                     }
                 }


### PR DESCRIPTION
To prevent XSS (#322) I've added `escapeHtml` option which allow to escape HTML characters both for title and message.

By default escaping is disabled. So if I run following code

     toastr.success("<strong>Message</strong>", "Hello <strong>toastr</strong>");

I will get message without escaping (same behavior as now).

![toastr1](https://cloud.githubusercontent.com/assets/800755/8999364/9aad277a-3752-11e5-9b64-9cc928e00483.PNG)

But if I enable this option

     toastr.options.escapeHtml = true;
     toastr.success("<strong>Message</strong>", "Hello <strong>toastr</strong>");

Result will be

![toastr2](https://cloud.githubusercontent.com/assets/800755/8999371/b90cb154-3752-11e5-926d-db52b87d5200.PNG)

At our project we are putting user's input directly into toastr, so in this case user can run any custom JS code. So it's definitely important feature.