### PR TITLE
Right To Left (RTL) Support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,3 @@ Thumbs.db
 # WebStorm #
 ######################
 .idea/
-
-#Local Development Files#
-vender
-local-demo.html
-local-toastr.js
-local-toastr.less

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ Thumbs.db
 # WebStorm #
 ######################
 .idea/
+
+#Local Development Files#
+vender
+local-demo.html
+local-toastr.js
+local-toastr.less

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Visually indicate how long before a toast expires.
     toastr.options.progressBar = true; 
 
 ### rtl
-Display the toastr from right-to-left, both for the text and icon.
+Flip the toastr to  be displayed properly for right-to-left languages.
     toastr.options.rtl = true; 
 
 ## Building Toastr

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Visually indicate how long before a toast expires.
 
     toastr.options.progressBar = true; 
 
+### rtl
+Display the toastr from right-to-left, both for the text and icon.
+    toastr.options.rtl = true; 
+
 ## Building Toastr
 
 To build the minified and css versions of Toastr you will need [node](http://nodejs.org) installed. (Use Homebrew or Chocolatey.)

--- a/demo.html
+++ b/demo.html
@@ -45,6 +45,11 @@
                         </label>
                     </div>
                     <div class="controls">
+                        <label class="checkbox" for="rtl">
+                            <input id="rtl" type="checkbox" value="checked" class="input-mini" />Right To Left
+                        </label>
+                    </div>
+                    <div class="controls">
                         <label class="checkbox" for="progressBar">
                             <input id="progressBar" type="checkbox" value="checked" class="input-mini" />Progress Bar
                         </label>
@@ -224,7 +229,8 @@
                 closeButton: $('#closeButton').prop('checked'),
                 debug: $('#debugInfo').prop('checked'),
                 newestOnTop: $('#newestOnTop').prop('checked'),
-                progressBar: $('#progressBar').prop('checked'),
+                rtl: $('#rtl').prop('checked'),
+				progressBar: $('#progressBar').prop('checked'),
                 positionClass: $('#positionGroup input:radio:checked').val() || 'toast-top-right',
                 preventDuplicates: $('#preventDuplicates').prop('checked'),
                 onclick: null

--- a/toastr.css
+++ b/toastr.css
@@ -85,8 +85,8 @@ button.toast-close-button {
 #toast-container {
   position: fixed;
   z-index: 999999;
+  pointer-events: none;
   /*overrides*/
-
 }
 #toast-container * {
   -moz-box-sizing: border-box;
@@ -95,6 +95,7 @@ button.toast-close-button {
 }
 #toast-container > div {
   position: relative;
+  pointer-events: auto;
   overflow: hidden;
   margin: 0 0 6px;
   padding: 15px 15px 15px 50px;
@@ -111,6 +112,12 @@ button.toast-close-button {
   opacity: 0.8;
   -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
   filter: alpha(opacity=80);
+}
+#toast-container > div.rtl {
+  direction: rtl;
+  margin: 0 0 6px;
+  padding: 15px 50px 15px 15px;
+  background-position: right 15px center;
 }
 #toast-container > :hover {
   -moz-box-shadow: 0 0 12px #000000;
@@ -168,15 +175,26 @@ button.toast-close-button {
   -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
   filter: alpha(opacity=40);
 }
+/*Right to left*/
+.rtl .toast-close-button {
+  left: -0.3em;
+  float: left;
+}
 /*Responsive Design*/
 @media all and (max-width: 240px) {
   #toast-container > div {
     padding: 8px 8px 8px 50px;
     width: 11em;
   }
+  #toast-container > div.rtl {
+    padding: 8px 50px 8px 8px;
+  }
   #toast-container .toast-close-button {
     right: -0.2em;
     top: -0.2em;
+  }
+  #toast-container .rtl .toast-close-button {
+    left: -0.2em;
   }
 }
 @media all and (min-width: 241px) and (max-width: 480px) {
@@ -184,14 +202,23 @@ button.toast-close-button {
     padding: 8px 8px 8px 50px;
     width: 18em;
   }
+  #toast-container > div.rtl {
+    padding: 8px 50px 8px 8px;
+  }
   #toast-container .toast-close-button {
     right: -0.2em;
     top: -0.2em;
+  }
+  #toast-container .rtl .toast-close-button {
+    left: -0.2em;
   }
 }
 @media all and (min-width: 481px) and (max-width: 768px) {
   #toast-container > div {
     padding: 15px 15px 15px 50px;
     width: 25em;
+  }
+  #toast-container > div.rtl {
+    padding: 15px 50px 15px 15px;
   }
 }

--- a/toastr.js
+++ b/toastr.js
@@ -184,6 +184,7 @@
                     closeHtml: '<button type="button">&times;</button>',
                     newestOnTop: true,
                     preventDuplicates: false,
+					rtl: false,
                     progressBar: false
                 };
             }
@@ -246,7 +247,8 @@
                     setTitle();
                     setMessage();
                     setCloseButton();
-                    setProgressBar();
+                    setRTL();
+					setProgressBar();
                     setSequence();
                 }
 
@@ -324,6 +326,12 @@
                     if (options.closeButton) {
                         $closeElement.addClass('toast-close-button').attr('role', 'button');
                         $toastElement.prepend($closeElement);
+                    }
+                }
+
+                function setRTL() {
+                    if (options.rtl) {
+                        $toastElement.addClass("rtl");
                     }
                 }
 

--- a/toastr.less
+++ b/toastr.less
@@ -158,6 +158,13 @@ button.toast-close-button {
 		.opacity(0.8);
 	}
 
+	> div.rtl {
+		direction: rtl;
+		margin: 0 0 6px;
+		padding: 15px 50px 15px 15px;
+		background-position: right 15px center;
+	}
+
 	> :hover {
 		.boxShadow(0 0 12px @black);
 		.opacity(1);
@@ -223,6 +230,16 @@ button.toast-close-button {
 	.opacity(0.4);
 }
 
+/*Right to left*/
+
+.rtl {
+    .toast-close-button {
+		left: -0.3em;
+		float: left;
+	}
+}
+
+
 /*Responsive Design*/
 
 @media all and (max-width: 240px) {
@@ -232,10 +249,16 @@ button.toast-close-button {
 			padding: 8px 8px 8px 50px;
 			width: 11em;
 		}
+		> div.rtl {
+			padding: 8px 50px 8px 8px;
+		}
 
 		& .toast-close-button {
 			right: -0.2em;
 			top: -0.2em;
+		}
+		& .rtl .toast-close-button {
+			left: -0.2em;
 		}
 	}
 }
@@ -246,10 +269,16 @@ button.toast-close-button {
 			padding: 8px 8px 8px 50px;
 			width: 18em;
 		}
+		> div.rtl {
+			padding: 8px 50px 8px 8px;
+		}
 
 		& .toast-close-button {
 			right: -0.2em;
 			top: -0.2em;
+		}
+		& .rtl .toast-close-button {
+			left: -0.2em;
 		}
 	}
 }
@@ -259,6 +288,9 @@ button.toast-close-button {
 		> div {
 			padding: 15px 15px 15px 50px;
 			width: 25em;
+		}
+		> div.rtl {
+			padding: 15px 50px 15px 15px;
 		}
 	}
 }


### PR DESCRIPTION
Right-to-left (RTL) support for toastr. That will enable support for languages such as Arabic.
A new option was added to toastr options (rtl), and of course, a function to add (.rtl) class to #toast-container > div.
In the css side the work is just flipping things and turning them in the other direction.
Originally I developed this for my website and thought it will be extremely useful if it is merged into the code base.

Thanks,
Musharraf Omer