### PR TITLE
Add jspm config

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,20 @@
   },
   "scripts": {
     "test": "gulp test"
+  },
+  "jspm": {
+    "main": "toastr",
+    "format": "global",
+    "dependencies": {
+      "jquery": "github:components/jquery",
+      "css": "github:systemjs/plugin-css"
+    },
+    "files": ["toastr.js", "build"],
+    "shim": {
+      "toastr": {
+        "deps": ["jquery", "./build/toastr.css!"],
+        "exports": "toastr"
+      }
+    }
   }
 }


### PR DESCRIPTION
Add configuration so that jspm users can easily consume toastr. Jspm requires that any expected globals be explicitly listed