### PR TITLE
clear delayed hide handlers

### DIFF
--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -567,6 +567,33 @@
         clearContainerChildren();
     });
 
+    module('subscription');
+    asyncTest('subscribe - triggers 2 visible and 2 hidden response notifications while clicking on a toast', 1, function () {
+        //Arrange
+        var $toast = [];
+        var expectedReponses = [];
+        //Act
+        toastr.subscribe(function(response) {
+          if(response.options.testId) {
+            expectedReponses.push(response);
+          }
+        })
+
+        $toast[0] = toastr.info(sampleMsg, sampleTitle, {testId : 1});
+        $toast[1] = toastr.info(sampleMsg, sampleTitle, {testId : 2});
+
+        $toast[1].click()
+
+        setTimeout(function () {
+            // Assert
+            ok(expectedReponses.length === 4);
+            //Teardown
+            clearContainerChildren();
+            toastr.subscribe(null);
+            start();
+        }, delay);
+    });
+
     module('order of appearance');
     test('Newest toast on top', 1, function () {
         //Arrange

--- a/toastr.js
+++ b/toastr.js
@@ -375,6 +375,7 @@
                         easing: easing,
                         complete: function () {
                             removeToast($toastElement);
+                            clearTimeout(intervalId);
                             if (options.onHidden && response.state !== 'hidden') {
                                 options.onHidden();
                             }


### PR DESCRIPTION
This PR fixes the issue of sending the same hide response twice if the toast got delayed by hover or click. There was actually a cleartimeout call missing.

Please give me feedback what do you think, a test case is included. 