### PR TITLE
added simple ARIA screen reader support #141

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -145,7 +145,6 @@
                 $container = $('<div/>')
                     .attr('id', options.containerId)
                     .addClass(options.positionClass)
-                    .attr('aria-live', 'polite')
                     .attr('role', 'alert');
 
                 $container.appendTo($(options.target));


### PR DESCRIPTION
The toast with role=alert works great with the screen reader JAWS (v.15). I did observe the duplicate announcement issue reported (#141). Found documentation on the alert role <http://www.w3.org/TR/wai-aria/roles#alert> which explained alert will automatically be treated as an aria-live="assertive" region. Therefore, the toastr template with aria-live="polite" is redundant and will cause the reader to announce the region a second time. After removing, tested with IE11 and JAWS v15 and the announcement occurred only once.

