### PR TITLE
Add a closeOnHover option.

### DIFF
--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -140,6 +140,33 @@
             start();
         }, delay);
     });
+    asyncTest('clear and show - clear toast after hover', 1, function () {
+        //Arrange
+        var $toast = toastr.info(sampleMsg, sampleTitle);
+        console.log($toast);
+        var $container = toastr.getContainer();
+        $toast.trigger("mouseout");
+        //Act
+        setTimeout(function () {
+            //Assert
+            ok($container.find('div.toast-title').length === 0, 'Toast clears after a mouse hover'); //Teardown
+            resetContainer();
+            start();
+        }, 500);
+    });
+    asyncTest('clear and show - do not clear toast after hover', 1, function () {
+        //Arrange
+        var $toast = toastr.info(sampleMsg, sampleTitle, { closeOnHover: false });
+        var $container = toastr.getContainer();
+        $toast.trigger("mouseout");
+        //Act
+        setTimeout(function () {
+            //Assert
+            ok($container.find('div.toast-title').length === 1, 'Toast does not clear after a mouse hover'); //Teardown
+            resetContainer();
+            start();
+        }, 500);
+    });
     test('clear and show - after clear all toasts new toast still appears', 1, function () {
         //Arrange
         var $toast = [];

--- a/toastr.js
+++ b/toastr.js
@@ -170,6 +170,7 @@
                     closeMethod: false,
                     closeDuration: false,
                     closeEasing: false,
+                    closeOnHover: true,
 
                     extendedTimeOut: 1000,
                     iconClasses: {
@@ -267,7 +268,10 @@
                 }
 
                 function handleEvents() {
-                    $toastElement.hover(stickAround, delayedHideToast);
+                    if (options.closeOnHover) {
+                        $toastElement.hover(stickAround, delayedHideToast);
+                    }
+
                     if (!options.onclick && options.tapToDismiss) {
                         $toastElement.click(hideToast);
                     }


### PR DESCRIPTION
Add a `closeOnHover` option. Defaults to true for backward compatibility. Can be set to `false` to disable the feature that closes a toast when the toast is hovered upon (technically after a mouseout event). This came about because I needed a toast with a countdown, but didn't want the hover events to clear it.

Example usage:
```javascript
// create a toast that is not closed by hover event, but will close when time out finishes.
toastr.options = {
  timeOut: 5000,
  extendedTimeOut: 0,
  closeOnHover: false
}
toastr.info("Message", "Title");
```