### PR TITLE
fix github.io mixed content

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>toastr examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
+    <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <link href="build/toastr.min.css" rel="stylesheet" type="text/css" />
     <style>
         .row {


### PR DESCRIPTION
Since github.io provides https support changing this to https fixes the page not loading bootstrap.