### PR TITLE
Add descendant div selector to hover

### DIFF
--- a/build/toastr.css
+++ b/build/toastr.css
@@ -113,7 +113,7 @@ button.toast-close-button {
   -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
   filter: alpha(opacity=80);
 }
-#toast-container > :hover {
+#toast-container > div:hover {
   -moz-box-shadow: 0 0 12px #000000;
   -webkit-box-shadow: 0 0 12px #000000;
   box-shadow: 0 0 12px #000000;


### PR DESCRIPTION
This fixes a bug with iOS on hover, causing links to be double clicked.