### PR TITLE
Allow generic calls to notify

### DIFF
--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -298,6 +298,39 @@
         $toast.remove();
         clearContainerChildren();
     });
+    module('generic');
+    test('generic - pass message and title', 2, function () {
+        //Arrange
+        //Act
+        var $toast = toastr.notify({message: sampleMsg, title: sampleTitle});
+        //Assert
+        equal($toast.find('div.toast-title').html(), sampleTitle, 'Sets title');
+        equal($toast.find('div.toast-message').html(), sampleMsg, 'Sets message');
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('generic - pass message, but no title', 2, function () {
+        //Arrange
+        //Act
+        var $toast = toastr.notify({message:sampleMsg}); //Assert
+        equal($toast.find('div.toast-title').length, 0, 'Sets empty title');
+        equal($toast.find('div.toast-message').html(), sampleMsg, 'Sets message');
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('generic - no message nor title', 2, function () {
+        //Arrange
+        //Act
+        var $toast = toastr.notify({});
+        //Assert
+        equal($toast.find('div.toast-title').length, 0, 'Sets empty title');
+        equal($toast.find('div.toast-message').length, 0, 'Sets empty message');
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
 
 
     module('escape html', {

--- a/toastr.js
+++ b/toastr.js
@@ -34,7 +34,8 @@
                 subscribe: subscribe,
                 success: success,
                 version: '2.1.2',
-                warning: warning
+                warning: warning,
+                notify: notify
             };
 
             var previousToast;


### PR DESCRIPTION
I wanted to extend different types of notifications.  And the rigidity of error, warning, info, and success didn't meet my needs.  Since these are just wrappers to notify, I thought that being able to call it directly would help my cause.