### PR TITLE
Fixed error class reference.

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -173,7 +173,7 @@
 
                     extendedTimeOut: 1000,
                     iconClasses: {
-                        error: 'toast-error',
+                        error: 'toast-danger',
                         info: 'toast-info',
                         success: 'toast-success',
                         warning: 'toast-warning'


### PR DESCRIPTION
The error class name is misspelled with the error class defined in css. When we run:

```javascript
toastr.error('error message here');
```
It doesn't show the formatted red error as the class name is referenced wrong.