### PR TITLE
package.json: explicitly name jquery dep (Fix #411)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
       "url": "http://www.opensource.org/licenses/mit-license.php"
     }
   ],
+  "dependencies": {
+    "jquery": ">=1.12.0"
+  },
   "devDependencies": {
     "del": "^0.1.3",
     "glob": "^4.0.6",


### PR DESCRIPTION
This is needed for build systems like Webpack and also for transparency.