### PR TITLE
Fix bootstrap link to work on HTTPS

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>toastr examples</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <link href="build/toastr.min.css" rel="stylesheet" type="text/css" />
     <style>
         .row {


### PR DESCRIPTION
The demo page at https://codeseven.github.io/toastr/demo.html does not load the Bootstrap CSS since it is loaded over HTTP while the page itself is served over HTTPS.
This is how the demo page appears in Chrome:
<img width="1439" alt="screen shot 2016-06-03 at 11 12 47 am" src="https://cloud.githubusercontent.com/assets/3721994/15772868/62a5129e-297c-11e6-880f-19cadd2d8b16.png">
I have updated the bootstrap link to be able to load over both HTTP and HTTPS.