### PR TITLE
fix multiple container creation if target option set to iframe/frameset.

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -55,7 +55,7 @@
 
             function getContainer(options, create) {
                 if (!options) { options = getOptions(); }
-                $container = $('#' + options.containerId);
+                $container = $(options.target).find('#' + options.containerId);
                 if ($container.length) {
                     return $container;
                 }


### PR DESCRIPTION
If target set to iframe or frameset, the existing container check (`$container.length`) will never find it and container will be recreated endlessly.
For exaple, target option can be used like so:
```
var frameDocument = $('frameset-selector, top.document)[0].contentDocument;
var mainframeBody = $(frameDocument).find('body');

toastr.options.target = mainframeBody;
```