### PR TITLE
Preserve `margin-bottom` of each toasts.

### DIFF
--- a/toastr.scss
+++ b/toastr.scss
@@ -136,12 +136,14 @@ button.toast-close-button {
 #toast-container.toast-top-center > div,
 #toast-container.toast-bottom-center > div {
   width: 300px;
-  margin: auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 #toast-container.toast-top-full-width > div,
 #toast-container.toast-bottom-full-width > div {
   width: 96%;
-  margin: auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 .toast {
   background-color: #030303;


### PR DESCRIPTION
`margin: auto;` overrides `margin: 0 0 6px;` of each toasts.
I replaced this with `margin-left` and `margin-right` properties.

The less file was fixed already at f43ee2af6f20ac203f17365e68d346b6f3204fc4.