### PR TITLE
Add default titles to all toast types as options

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -49,7 +49,7 @@
                     iconClass: getOptions().iconClasses.error,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().errorTitle
                 });
             }
 
@@ -71,7 +71,7 @@
                     iconClass: getOptions().iconClasses.info,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().infoTitle
                 });
             }
 
@@ -85,7 +85,7 @@
                     iconClass: getOptions().iconClasses.success,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().successTitle
                 });
             }
 
@@ -95,7 +95,7 @@
                     iconClass: getOptions().iconClasses.warning,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().warningTitle
                 });
             }
 
@@ -169,7 +169,10 @@
                     closeDuration: false,
                     closeEasing: false,
                     closeOnHover: true,
-
+                    successTitle: undefined,
+                    errorTitle: undefined,
+                    warningTitle: undefined,
+                    infoTitle: undefined,
                     extendedTimeOut: 1000,
                     iconClasses: {
                         error: 'toast-error',


### PR DESCRIPTION
Adds the ability to set a default title for each of the 4 toasts.

Uses the title passed into the function if available, otherwise uses default.