### PR TITLE
Add ability to specify default toast titles per toast type

### DIFF
--- a/tests/unit/toastr-tests.js
+++ b/tests/unit/toastr-tests.js
@@ -322,6 +322,67 @@
         $toast.remove();
         clearContainerChildren();
     });
+    
+    module('default titles', {
+        teardown: function() {
+            toastr.options.successTitle = undefined,
+            toastr.options.errorTitle = undefined,
+            toastr.options.warningTitle = undefined,
+            toastr.options.infoTitle = undefined
+        }
+    });
+    test('success - has default title', 2, function() {
+        var title = 'Success';
+        //Arrange
+        toastr.options.successTitle = title;
+        //Act
+        var $toast = toastr.success('My success toast');
+        //Assert
+        equal($toast.find('div.toast-title').length, 1, 'Has a default title');
+        equal($toast.find('div.toast-title').html(), title, 'Title matches our default title')
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('error - has default title', 2, function() {
+        var title = 'Error';
+        //Arrange
+        toastr.options.errorTitle = title;
+        //Act
+        var $toast = toastr.error('My error toast');
+        //Assert
+        equal($toast.find('div.toast-title').length, 1, 'Has a default title');
+        equal($toast.find('div.toast-title').html(), title, 'Title matches our default title')
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('warning - has default title', 2, function() {
+        var title = 'warning';
+        //Arrange
+        toastr.options.warningTitle = title;
+        //Act
+        var $toast = toastr.warning('My warning toast');
+        //Assert
+        equal($toast.find('div.toast-title').length, 1, 'Has a default title');
+        equal($toast.find('div.toast-title').html(), title, 'Title matches our default title')
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
+    test('info - has default title', 2, function() {
+        var title = 'info';
+        //Arrange
+        toastr.options.infoTitle = title;
+        //Act
+        var $toast = toastr.info('My info toast');
+        //Assert
+        equal($toast.find('div.toast-title').length, 1, 'Has a default title');
+        equal($toast.find('div.toast-title').html(), title, 'Title matches our default title')
+        //Teardown
+        $toast.remove();
+        clearContainerChildren();
+    });
 
 
     module('escape html', {

--- a/toastr.js
+++ b/toastr.js
@@ -49,7 +49,7 @@
                     iconClass: getOptions().iconClasses.error,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().errorTitle
                 });
             }
 
@@ -71,7 +71,7 @@
                     iconClass: getOptions().iconClasses.info,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().infoTitle
                 });
             }
 
@@ -85,7 +85,7 @@
                     iconClass: getOptions().iconClasses.success,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().successTitle
                 });
             }
 
@@ -95,7 +95,7 @@
                     iconClass: getOptions().iconClasses.warning,
                     message: message,
                     optionsOverride: optionsOverride,
-                    title: title
+                    title: title || getOptions().warningTitle
                 });
             }
 
@@ -169,7 +169,10 @@
                     closeDuration: false,
                     closeEasing: false,
                     closeOnHover: true,
-
+                    successTitle: undefined,
+                    errorTitle: undefined,
+                    warningTitle: undefined,
+                    infoTitle: undefined,
                     extendedTimeOut: 1000,
                     iconClasses: {
                         error: 'toast-error',


### PR DESCRIPTION
Adds the ability to specifiy a default title per toast type in the options:

`toastr.options.successTitle = 'Success!';`
`toastr.options.errorTitle = Error!';`
`toastr.options.warningTitle = 'Warning!';`
`toastr.options.infoTitle ='Info!';`

If you pass a title to the toast, `toastr.success('My successful toast message', 'Custom Success Title');` it will override the default title.