### PR TITLE
fix(gulp): stop test when karma complete with non-zero exitCode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,8 +144,12 @@ function startTests(singleRun, done) {
 
     ////////////////
 
-    function karmaCompleted() {
-        done();
+    function karmaCompleted(exitCode) {
+        if (exitCode === 0) {
+            done();
+        } else {
+            process.exit(exitCode);
+        }
     }
 }
 


### PR DESCRIPTION
It should fail the builds as expected.