### PR TITLE
Update toastr.scss

### DIFF
--- a/toastr.scss
+++ b/toastr.scss
@@ -85,6 +85,7 @@ button.toast-close-button {
 #toast-container {
   position: fixed;
   z-index: 999999;
+  pointer-events: none;
   /*overrides*/
 
 }


### PR DESCRIPTION
Missing ```pointer-events: none;``` rule for #toast-container in scss