### PR TITLE
Add typescript definition npm source

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ bower install toastr
 #### [npm](https://www.npmjs.com/package/toastr)
 ```
 npm install --save toastr
+
+// If using within a TypeScript project, also get the TypeScript Definition file
+npm install -D @types/toastr
+
 ```
 
 #### [Ruby on Rails](https://github.com/tylergannon/toastr-rails)


### PR DESCRIPTION
I added the reference to the definitely typed package for the typescript definition, so that people don't have to search around for where the definition file is.