### PR TITLE
Add .npmignore to remove extra files from node_modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,78 @@
+/nuget
+/package
+/tests
+
+.gitattributes
+.jscsrc
+.jshintrc
+.npmignore
+.travis.yml
+demo.html
+gulpfile.js
+karma.conf.js
+release*checklist.md
+toastr-icon.png
+toastr.js
+toastr.less
+toastr.scss
+
+# Copied from .gitignore #
+##########################
+
+bower_components
+
+# Ignore Visual Studio  Project #
+###################
+*.config
+*.user
+*.csproj
+*.gpState
+*.sln
+*.suo
+/bin
+/obj
+/packages
+/Properties
+/Scripts
+/report
+/tests/coverage
+
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+
+# WebStorm #
+######################
+.idea/


### PR DESCRIPTION
toastr's entry in node_modules contains a lot of files that don't look like they belong there. There is `package` which seems to be a copy of the package, `nuget` which contains all of the nuget releases, and `tests` which is all of the unit tests.

All of these extra files adds up to hundreds of gigabytes of unnecessary downloads each month. I didn't dive super deep into your build process, but I put together an `.npmignore` file which I think will clean up your published NPM package to only the files that are needed to use toastr.

https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package

<img width="281" alt="screen shot 2017-10-23 at 4 42 57 pm" src="https://user-images.githubusercontent.com/2754163/31914697-4da69b86-b811-11e7-9034-91992bbfd0e3.png">
