### PR TITLE
Enable type specific default options

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -190,7 +190,8 @@
                     preventDuplicates: false,
                     progressBar: false,
                     progressClass: 'toast-progress',
-                    rtl: false
+                    rtl: false,
+                    typeBasedOverrides: {}
                 };
             }
 
@@ -201,7 +202,12 @@
 
             function notify(map) {
                 var options = getOptions();
-                var iconClass = map.iconClass || options.iconClass;
+
+                // extend the options object with type specific overrides
+                if (typeof (options.typeBasedOverrides[map.type]) !== 'undefined') {
+                    options = $.extend(options, options.typeBasedOverrides[map.type]);
+                    iconClass = options.typeBasedOverrides[map.type] || iconClass;
+                }
 
                 if (typeof (map.optionsOverride) !== 'undefined') {
                     options = $.extend(options, map.optionsOverride);

--- a/toastr.js
+++ b/toastr.js
@@ -202,11 +202,13 @@
 
             function notify(map) {
                 var options = getOptions();
+				
+                var iconClass = map.iconClass || options.iconClass;
 
                 // extend the options object with type specific overrides
                 if (typeof (options.typeBasedOverrides[map.type]) !== 'undefined') {
                     options = $.extend(options, options.typeBasedOverrides[map.type]);
-                    iconClass = options.typeBasedOverrides[map.type] || iconClass;
+                    iconClass = options.typeBasedOverrides[map.type].iconClass || iconClass;
                 }
 
                 if (typeof (map.optionsOverride) !== 'undefined') {


### PR DESCRIPTION
Enables users to create type-specific override options during initial toastr configuration while maintaining the hierarchy of option inheritance.

This is the patch associated with issue #571 

This is not a breaking change but I haven't documented it until it's accepted.