### PR TITLE
Update for jQuery 3

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -140,19 +140,15 @@
                     };
                     switch (options.hideMethod) {
                         case 'fadeOut':
-                            console.log('fadeOut');
                             $toastElement.fadeOut(animationOptions);
                             break;
                         case 'slideUp':
-                            console.log('slideUp');
                             $toastElement.slideUp(animationOptions);
                             break;
                         case 'hide':
-                            console.log('hide');
                             $toastElement.hide(animationOptions);
                             break;
                         default:
-                            console.log('default');
                             $toastElement.hide(animationOptions);
                     }
                     return true;
@@ -461,19 +457,15 @@
                     };
                     switch (method) {
                         case 'fadeOut':
-                            console.log('fadeout');
                             return $toastElement.fadeOut(animationOptions);
                             break;
                         case 'slideUp':
-                            console.log('slideUp');
                             return $toastElement.slideUp(animationOptions);
                             break;
                         case 'hide':
-                            console.log('hide');
                             return $toastElement.hide(animationOptions);
                             break;
                         default:
-                            console.log('default');
                             return $toastElement.hide(animationOptions);
                     }
                 }

--- a/toastr.js
+++ b/toastr.js
@@ -131,11 +131,30 @@
             function clearToast ($toastElement, options, clearOptions) {
                 var force = clearOptions && clearOptions.force ? clearOptions.force : false;
                 if ($toastElement && (force || $(':focus', $toastElement).length === 0)) {
-                    $toastElement[options.hideMethod]({
+                    const animationOptions = {
                         duration: options.hideDuration,
                         easing: options.hideEasing,
-                        complete: function () { removeToast($toastElement); }
-                    });
+                        complete: function() {
+                            removeToast($toastElement);
+                        }
+                    };
+                    switch (options.hideMethod) {
+                        case 'fadeOut':
+                            console.log('fadeOut');
+                            $toastElement.fadeOut(animationOptions);
+                            break;
+                        case 'slideUp':
+                            console.log('slideUp');
+                            $toastElement.slideUp(animationOptions);
+                            break;
+                        case 'hide':
+                            console.log('hide');
+                            $toastElement.hide(animationOptions);
+                            break;
+                        default:
+                            console.log('default');
+                            $toastElement.hide(animationOptions);
+                    }
                     return true;
                 }
                 return false;
@@ -320,9 +339,24 @@
                 function displayToast() {
                     $toastElement.hide();
 
-                    $toastElement[options.showMethod](
-                        {duration: options.showDuration, easing: options.showEasing, complete: options.onShown}
-                    );
+                    const animationOptions = {
+                        duration: options.showDuration,
+                        easing: options.showEasing,
+                        complete: options.onShown
+                    };
+                    switch (options.showMethod) {
+                        case 'fadeIn':
+                            $toastElement.fadeIn(animationOptions);
+                            break;
+                        case 'slideDown':
+                            $toastElement.slideDown(animationOptions);
+                            break;
+                        case 'show':
+                            $toastElement.show(animationOptions);
+                            break;
+                        default:
+                            $toastElement.show(animationOptions);
+                    }
 
                     if (options.timeOut > 0) {
                         intervalId = setTimeout(hideToast, options.timeOut);
@@ -410,10 +444,11 @@
                         return;
                     }
                     clearTimeout(progressBar.intervalId);
-                    return $toastElement[method]({
+
+                    const animationOptions = {
                         duration: duration,
                         easing: easing,
-                        complete: function () {
+                        complete: function() {
                             removeToast($toastElement);
                             clearTimeout(intervalId);
                             if (options.onHidden && response.state !== 'hidden') {
@@ -423,7 +458,24 @@
                             response.endTime = new Date();
                             publish(response);
                         }
-                    });
+                    };
+                    switch (method) {
+                        case 'fadeOut':
+                            console.log('fadeout');
+                            return $toastElement.fadeOut(animationOptions);
+                            break;
+                        case 'slideUp':
+                            console.log('slideUp');
+                            return $toastElement.slideUp(animationOptions);
+                            break;
+                        case 'hide':
+                            console.log('hide');
+                            return $toastElement.hide(animationOptions);
+                            break;
+                        default:
+                            console.log('default');
+                            return $toastElement.hide(animationOptions);
+                    }
                 }
 
                 function delayedHideToast() {


### PR DESCRIPTION
I'm using Toastr for a project that uses jQuery 3. This fails on `$toastElement[options.hideMethod]({` and `$toastElement[options.showMethod](` and `return $toastElement[method]({`.

So I updated the JS to make it work.