### PR TITLE
Update license package.json license property for new format

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
     "url": "git://github.com/CodeSeven/toastr.git"
   },
   "bugs": "http://stackoverflow.com/questions/tagged/toastr",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "jquery": ">=1.12.0"
   },


### PR DESCRIPTION
It seems you are using a deprecated license format in package.json. I updated it according the official [documentation](https://docs.npmjs.com/files/package.json#license)