### PR TITLE
Use 2.1.4 instead of 'latest' on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Browser testing provided by BrowserStack.
 Toastr is hosted at cdnjs and jsdelivr
 
 #### Debug
-- [//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.css](//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.css)
+- [//cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.css](//cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.css)
 
 #### Minified
-- [//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js](//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js)
-- [//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css](//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css)
+- [//cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js](//cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.js)
+- [//cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css](//cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.4/toastr.min.css)
 
 ## Install
 


### PR DESCRIPTION
Use the actual latest version (2.1.4) for the cdnjs links as 'latest' on cdnjs for this library is not maintained and an older version.