### PR TITLE
Stripping 'script' tag from message text.

### DIFF
--- a/toastr.js
+++ b/toastr.js
@@ -368,6 +368,11 @@
                 function setMessage() {
                     if (map.message) {
                         var suffix = map.message;
+						
+						// BeardedFaisal (23-Aug-2019)
+						// Stripping out <script> tag to avoid JS injection.
+						suffix = suffix.replace(/(<([^>]+)>)/ig,"")
+						
                         if (options.escapeHtml) {
                             suffix = escapeHtml(map.message);
                         }


### PR DESCRIPTION
Idea is to remove <script> tags to avoid JS being injected/executed. 

![image](https://user-images.githubusercontent.com/6344297/63566241-a7ff8400-c5af-11e9-9b61-20fe8be3cc0a.png)
