### PR TITLE
docs: Fix simple typo, perentage -> percentage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,7 +169,7 @@ function bytediffFormatter(data) {
  * Format a number as a percentage
  * @param  {Number} num       Number to format as a percent
  * @param  {Number} precision Precision of the decimal
- * @return {Number}           Formatted perentage
+ * @return {Number}           Formatted percentage
  */
 function formatPercent(num, precision) {
     return (num * 100).toFixed(precision);


### PR DESCRIPTION
There is a small typo in gulpfile.js.

Should read `percentage` rather than `perentage`.

